### PR TITLE
Add holiday function to OLX Helper

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,18 +51,19 @@ time.sleep(3)
 # Get list of offers and save them to list 
 adList = get_marketplace_offer_list(driver)
 
-navigate_to_offer_edit(driver, adList[0].ID)
+holiday_description = " - Jestem na urlopie w związku z czym cena podniesiona o 50zł za fatyge i dodatkowe koszty związane z wysyłką. Pozdrawiam"
+price_increase = 50
 
-get_offer_description(driver, adList[0])
-
-append_to_offer_description(driver, adList[0], " - Jestem na urlopie w związku z czym cena podniesiona o 50zł za fatyge i dodatkowe koszty związane z wysyłką. Pozdrawiam")
-
-change_offer_price(driver, adList[0], int(adList[0].price) + 50)
-
-click_element_by_test_id(driver, 'submit-btn')
-
-time.sleep(3)
-
+for offer in adList:
+    navigate_to_offer_edit(driver, offer.ID)
+    if validate_is_holiday_description(driver, offer, holiday_description):
+        remove_holiday_description(driver, offer, holiday_description)
+        revert_offer_price(driver, offer, int(offer.price) - price_increase)
+    else:
+        append_to_offer_description(driver, offer, holiday_description)
+        change_offer_price(driver, offer, int(offer.price) + price_increase)
+    click_element_by_test_id(driver, 'submit-btn')
+    time.sleep(3)
 
 # Close the browser
 driver.quit()

--- a/methods.py
+++ b/methods.py
@@ -145,3 +145,26 @@ def change_offer_price(driver, offer, new_price):
         offer.price = new_price
     except NoSuchElementException:
         print("Price element not found.")
+
+def remove_holiday_description(driver, offer, holiday_description):
+    try:
+        wait_for_element(driver, By.CSS_SELECTOR, '[data-cy="posting-description"]')
+        description_element = driver.find_element(By.CSS_SELECTOR, '[data-cy="posting-description"]')
+        current_description = description_element.text
+        new_description = current_description.replace(holiday_description, "").strip()
+        description_element.clear()
+        description_element.send_keys(new_description)
+        offer.description = new_description
+    except NoSuchElementException:
+        print("Description element not found.")
+
+def revert_offer_price(driver, offer, original_price):
+    try:
+        wait_for_element(driver, By.CSS_SELECTOR, '[data-cy="posting-price"]')
+        price_element = driver.find_element(By.CSS_SELECTOR, '[data-cy="posting-price"]')
+        price_element.send_keys(Keys.CONTROL + "a")
+        price_element.send_keys(Keys.DELETE)
+        price_element.send_keys(original_price)
+        offer.price = original_price
+    except NoSuchElementException:
+        print("Price element not found.")


### PR DESCRIPTION
Add functionality to handle holiday mode for OLX listings.

* **main.py**
  - Add a loop to iterate through all listings and apply holiday mode.
  - Add a check to see if an offer is already in holiday mode.
  - Add code to revert changes if the offer is already in holiday mode.

* **methods.py**
  - Add a new function `remove_holiday_description` to remove the holiday description.
  - Add a new function `revert_offer_price` to revert the price change.
  - Update `validate_is_holiday_description` to check if an offer is already in holiday mode.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Karolbrauza/OLX_Helper?shareId=da3f7d0c-9d7c-436f-90aa-2635aaceacfc).